### PR TITLE
Increase maximum restart delay to 90 seconds

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -72,7 +72,7 @@ var csts = {
   MODULE_CONF_PREFIX: 'module-db-v2',
   MODULE_CONF_PREFIX_TAR: 'tar-modules',
 
-  EXP_BACKOFF_RESET_TIMER : parseInt(process.env.EXP_BACKOFF_RESET_TIMER) || 120000,
+  EXP_BACKOFF_RESET_TIMER : parseInt(process.env.EXP_BACKOFF_RESET_TIMER) || 30000,
   REMOTE_PORT_TCP         : isNaN(parseInt(process.env.KEYMETRICS_PUSH_PORT)) ? 80 : parseInt(process.env.KEYMETRICS_PUSH_PORT),
   REMOTE_PORT             : 41624,
   REMOTE_HOST             : 's1.keymetrics.io',

--- a/constants.js
+++ b/constants.js
@@ -72,7 +72,7 @@ var csts = {
   MODULE_CONF_PREFIX: 'module-db-v2',
   MODULE_CONF_PREFIX_TAR: 'tar-modules',
 
-  EXP_BACKOFF_RESET_TIMER : parseInt(process.env.EXP_BACKOFF_RESET_TIMER) || 30000,
+  EXP_BACKOFF_RESET_TIMER : parseInt(process.env.EXP_BACKOFF_RESET_TIMER) || 120000,
   REMOTE_PORT_TCP         : isNaN(parseInt(process.env.KEYMETRICS_PUSH_PORT)) ? 80 : parseInt(process.env.KEYMETRICS_PUSH_PORT),
   REMOTE_PORT             : 41624,
   REMOTE_HOST             : 's1.keymetrics.io',

--- a/lib/God.js
+++ b/lib/God.js
@@ -472,7 +472,7 @@ God.handleExit = function handleExit(clu, exit_code, kill_signal) {
       restart_delay = proc.pm2_env.exp_backoff_restart_delay
     }
     else {
-      proc.pm2_env.prev_restart_delay = Math.floor(Math.min(15000, proc.pm2_env.prev_restart_delay * 1.5))
+      proc.pm2_env.prev_restart_delay = Math.floor(Math.min(90000, proc.pm2_env.prev_restart_delay * 1.5))
       restart_delay = proc.pm2_env.prev_restart_delay
     }
     console.log(`App [${clu.pm2_env.name}:${clu.pm2_env.pm_id}] will restart in ${restart_delay}ms`)


### PR DESCRIPTION
Roll-out checklist

* Confirm that standard rollback of reverting commit will work

  Reverting this change and the related server PR will revert these changes.

* Pick time of day/week to minimize customer impact if there is an issue discovered after deployment

  This should be shipped during the evening

* Pick and implement phase rollout approach

  This is not eligible for a phased rollout
